### PR TITLE
#84 Hide development folder's panel from New and edit schedule pages

### DIFF
--- a/src/api/getPanels.api.ts
+++ b/src/api/getPanels.api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { SelectableValue } from '@grafana/data';
-import { getBackendSrv, MetaAnalyticsEventName } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 import { DashboardMeta, DashboardResponse, Panel, SelectableVariable, Variable } from 'types';
 import { panelUsesUnsupportedMacro, panelUsesVariable } from 'utils/checkers.utils';
 import { getDatasource } from './getDatasource.api';

--- a/src/api/getPanels.api.ts
+++ b/src/api/getPanels.api.ts
@@ -1,5 +1,6 @@
+/* eslint-disable no-console */
 import { SelectableValue } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, MetaAnalyticsEventName } from '@grafana/runtime';
 import { DashboardMeta, DashboardResponse, Panel, SelectableVariable, Variable } from 'types';
 import { panelUsesUnsupportedMacro, panelUsesVariable } from 'utils/checkers.utils';
 import { getDatasource } from './getDatasource.api';
@@ -90,16 +91,19 @@ export const getPanels = async (datasourceID: number): Promise<Panel[]> => {
 
 export const getDashboards = async () => {
   const dashboardMeta = await searchForDashboards();
-  const dashboardResponses = await Promise.all<DashboardResponse>(dashboardMeta.map(({ uid }) => getDashboard(uid)));
+  const newDashboardMeta = dashboardMeta.filter(({ folderTitle, type }) =>
+    type !== 'dash-folder' && !!folderTitle ? folderTitle.toLowerCase() !== 'develop' : true
+  );
+  const dashboardResponses = await Promise.all<DashboardResponse>(newDashboardMeta.map(({ uid }) => getDashboard(uid)));
   return dashboardResponses.map(({ dashboard }) => dashboard);
 };
 
 export const getDashboard = async (uuid: string): Promise<DashboardResponse> => {
-  return getBackendSrv().get(`./api/dashboards/uid/${uuid}`);
+  return await getBackendSrv().get(`./api/dashboards/uid/${uuid}`);
 };
 
 export const searchForDashboards = async (): Promise<DashboardMeta[]> => {
-  return getBackendSrv().get('./api/search');
+  return await getBackendSrv().get('./api/search');
 };
 
 export const refreshPanelOptions = async (

--- a/src/api/getPanels.api.ts
+++ b/src/api/getPanels.api.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { SelectableValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardMeta, DashboardResponse, Panel, SelectableVariable, Variable } from 'types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,8 @@ export type DashboardResponse = {
 
 export type DashboardMeta = {
   uid: string;
+  folderTitle: string;
+  type: string;
 };
 
 /**


### PR DESCRIPTION
Fixes #84

## Test

- [ ] Create a `develop` folder. It could be `Develop` the check is case insensitive.
- [ ] Move or create panels in the `develop` folder.
- [ ] Go to Excel Report email scheduler > Schedulers.
- [ ] Create or edit a schedule 
- [ ] See the panels in develop folder are not in the list of available panels