### PR TITLE
#89 Scheduler Page: Selected Panel variables disappear on refresh

### DIFF
--- a/src/components/schedule/panel/PanelList.tsx
+++ b/src/components/schedule/panel/PanelList.tsx
@@ -79,7 +79,8 @@ const PanelList: React.FC<PanelListProps> = ({ panelListError, onPanelChecked, c
                 checkedPanels={checkedPanels}
                 panelDetail={
                   panelDetails.find(
-                    (detail: PanelDetails) => detail.panelID === panel.id && detail.dashboardID === panel.dashboardID
+                    (detail: PanelDetails) =>
+                      detail.id !== '' && detail.panelID === panel.id && detail.dashboardID === panel.dashboardID
                   )!
                 }
               />


### PR DESCRIPTION
Fixes #89

# Description

- It was not loading because it was being overridden by the next panel 🤷🏼 

## Test

- [ ] Go to scheduler page to create and edit a schedule.
- [ ] Select panels and then set loopback period and other data of the panel.
- [ ] Go back to the main page and come back to the page. Refresh the schedule page a few time. The selected data should still be there.
- [ ] Update the data and do the same as above steps. The new data should not disapperar.